### PR TITLE
Add configuration setting for LSP binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
+        "imandrax.lsp.binary": {
+          "scope": "window",
+          "type": "string",
+          "default": "imandrax-lsp",
+          "description": "Path to the ImandraX LSP server binary"
+        },
         "imandrax.lsp.arguments": {
           "scope": "window",
           "type": "array",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,10 +20,11 @@ export function activate(context: ExtensionContext) {
 
 	// Start language server
 	const config = workspace.getConfiguration('imandrax');
+	const binary = config.lsp.binary;
 	const server_args = config.lsp.arguments;
 	const server_env = config.lsp.environment;
 
-	const executable_options = { command: "imandrax_lsp", args: server_args, env: server_env /* transport: TransportKind.stdio */ };
+	const executable_options = { command: binary, args: server_args, env: server_env /* transport: TransportKind.stdio */ };
 	const serverOptions: ServerOptions = executable_options;
 
 	// Options to control the language client


### PR DESCRIPTION
This adds a configuration setting that lets us customize the path to the LSP binary. E.g. `imandrax_lsp` vs `imandrax-lsp` and different paths.