### PR TITLE
Render List.append as @ and keep functions fully qualified in goal state

### DIFF
--- a/src/goal-state/term-formatter.ts
+++ b/src/goal-state/term-formatter.ts
@@ -404,15 +404,11 @@ class TermFormatter {
     }
     if (hover_enabled && definition) hover += sanitize(definition);
 
-    // Map operator names to their visual form if different, e.g. `iff` vs `<==>`
+    // Map operator names to their visual form if different, e.g. `iff` vs
+    // `<==>`, or `List.append` vs `@`. Names that don't have a special visual
+    // form are kept fully qualified (e.g. `List.length`).
     const op_info = IXO.operator_info(sid);
-    let op_name = op_info.name == "" ? sid : op_info.name;
-
-    // Strip all module names preceding the op_name; it's still in the hover if
-    // the user needs to see it.
-    const dot_inx = sid.lastIndexOf(".");
-    if (dot_inx > 0 && dot_inx < sid.length - 1)
-      op_name = sid.substring(dot_inx + 1);
+    const op_name = op_info.name == "" ? sid : op_info.name;
 
     return vtext(span(id_fun(op_name, s.id), hover), op_name.length);
   }


### PR DESCRIPTION
The goal-state term formatter mapped List.append to @ and computed the proper operator name, but a subsequent module-stripping step overwrote it, turning @ back into infix append and shortening List.length to length.

Drop the module-stripping so operator aliases (@, <==>, ==>) survive and ordinary functions stay fully qualified (List.length). The full id remains available in the hover.

i.e., PR for going from this:

<img width="1365" height="383" alt="image" src="https://github.com/user-attachments/assets/50c1a03c-cc69-40d6-aabb-bb7636310196" />

to this:

<img width="1400" height="383" alt="image" src="https://github.com/user-attachments/assets/e73bfbc3-e4bb-45fe-a215-ab369015a588" />
